### PR TITLE
Cleanup scripts

### DIFF
--- a/scripts/address_conversion.py
+++ b/scripts/address_conversion.py
@@ -6,7 +6,6 @@ This module provides functions for converting between different address formats
 used in blockchain systems. It supports conversion between SS58 addresses (used
 in Substrate-based chains) and H160 addresses (Ethereum-style addresses).
 """
-
 import hashlib
 
 import bittensor_wallet

--- a/scripts/associate_evm_key.py
+++ b/scripts/associate_evm_key.py
@@ -1,0 +1,43 @@
+import argparse
+import json
+import pathlib
+import sys
+
+import bittensor
+
+from subtensor import associate_evm_key
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wallet-name", required=True)
+    parser.add_argument("--wallet-hotkey", required=True)
+    parser.add_argument("--wallet-path")
+    parser.add_argument("--network", default="finney")
+    parser.add_argument("--netuid", type=int, default=12)
+    args = parser.parse_args()
+
+    wallet = bittensor.Wallet(
+        name=args.wallet_name,
+        hotkey=args.wallet_hotkey,
+        path=args.wallet_path,
+    )
+
+    keyfile = (
+        pathlib.Path(wallet.path)
+        .expanduser()
+        .joinpath(wallet.name, "h160", wallet.hotkey_str)
+        .resolve()
+    )
+    evm_private_key = json.loads(keyfile.read_text())["private_key"]
+
+    with bittensor.subtensor(network=args.network) as subtensor:
+        success, error = associate_evm_key(subtensor, wallet, evm_private_key, args.netuid)
+
+    if not success:
+        print(f"Unable to Associate EVM Key. {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -31,9 +31,18 @@ def load_contract_abi():
     return json.loads(abi_file.read_text())
 
 
+RPC_URLS = {
+    "finney": "https://lite.chain.opentensor.ai",
+    "test": "https://test.chain.opentensor.ai",
+}
+
+
 def get_web3_connection(network: str) -> Web3:
     """Get Web3 connection for the specified network."""
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(network)
+    if network in RPC_URLS:
+        network_url = RPC_URLS[network]
+    else:
+        _, network_url = bittensor.utils.determine_chain_endpoint_and_network(network)
     w3 = Web3(web3.providers.auto.load_provider_from_uri(URI(network_url)))
     if not w3.is_connected():
         raise ConnectionError("Failed to connect to the network")

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -40,9 +40,13 @@ def get_web3_connection(rpc_url=None):
     return w3
 
 
-def get_account():
-    """Get account from PRIVATE_KEY environment variable."""
-    private_key = os.getenv("PRIVATE_KEY")
+def get_account(keyfile=None):
+    """Get the account from the keyfile or PRIVATE_KEY environment variable."""
+    if keyfile:
+        account_data = json.loads(pathlib.Path(keyfile).expanduser().read_text())
+        private_key = account_data.get("private_key")
+    else:
+        private_key = os.getenv("PRIVATE_KEY")
     if not private_key:
         raise KeyError("PRIVATE_KEY environment variable not set")
     return Account.from_key(private_key)

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -15,6 +15,8 @@ import pathlib
 import sys
 import json
 import hashlib
+
+import bittensor
 import requests
 import web3.providers.auto
 from web3 import Web3
@@ -155,3 +157,28 @@ def get_revert_reason(w3, tx_hash, block_number):
                         return item['name']
         return "Could not parse error"
     return "Could not parse error"
+
+
+def get_evm_key_associations(
+    subtensor: bittensor.Subtensor, netuid: int, block: int | None = None
+) -> dict[int, str]:
+    """
+    Retrieve all EVM key associations for a specific subnet.
+
+    Arguments:
+        subtensor (bittensor.Subtensor): The Subtensor object to use for querying the network.
+        netuid (int): The NetUID for which to retrieve EVM key associations.
+        block (int | None, optional): The block number to query. Defaults to None, which queries the latest block.
+
+    Returns:
+        dict: A dictionary mapping UIDs (int) to their associated EVM key addresses (str).
+    """
+    associations = subtensor.query_map_subtensor(
+        "AssociatedEvmAddress", block=block, params=[netuid]
+    )
+    uid_evm_address_map = {}
+    for uid, scale_obj in associations:
+        evm_address_raw, block = scale_obj.value
+        evm_address = "0x" + bytes(evm_address_raw[0]).hex()
+        uid_evm_address_map[uid] = evm_address
+    return uid_evm_address_map

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -19,6 +19,7 @@ import hashlib
 import bittensor
 import requests
 import web3.providers.auto
+from eth_typing import URI
 from web3 import Web3
 from eth_account import Account
 from web3.exceptions import ContractLogicError
@@ -30,9 +31,10 @@ def load_contract_abi():
     return json.loads(abi_file.read_text())
 
 
-def get_web3_connection(rpc_url):
-    """Get Web3 connection from RPC_URL environment variable."""
-    w3 = Web3(web3.providers.auto.load_provider_from_uri(rpc_url))
+def get_web3_connection(network: str) -> Web3:
+    """Get Web3 connection for the specified network."""
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(network)
+    w3 = Web3(web3.providers.auto.load_provider_from_uri(URI(network_url)))
     if not w3.is_connected():
         raise ConnectionError("Failed to connect to the network")
     return w3
@@ -80,7 +82,7 @@ def build_and_send_transaction(
     )
 
     signed_txn = w3.eth.account.sign_transaction(transaction, account.key)
-    
+
     tx_hash = w3.eth.send_raw_transaction(signed_txn.raw_transaction)
     print(f"Transaction sent: {tx_hash.hex()}", file=sys.stderr)
     return tx_hash

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -28,12 +28,8 @@ def load_contract_abi():
     return json.loads(abi_file.read_text())
 
 
-def get_web3_connection(rpc_url=None):
+def get_web3_connection(rpc_url):
     """Get Web3 connection from RPC_URL environment variable."""
-    rpc_url = rpc_url or os.getenv("RPC_URL")
-    if not rpc_url:
-        raise KeyError("RPC_URL environment variable is not set")
-
     w3 = Web3(web3.providers.auto.load_provider_from_uri(rpc_url))
     if not w3.is_connected():
         raise ConnectionError("Failed to connect to the network")

--- a/scripts/deny_request.py
+++ b/scripts/deny_request.py
@@ -10,6 +10,7 @@ transparency and accountability.
 
 import sys
 import argparse
+import bittensor.utils
 from common import (
     load_contract_abi,
     get_web3_connection,
@@ -85,9 +86,11 @@ def main():
     )
     parser.add_argument("--url", required=True, help="URL containing the reason for denial")
     parser.add_argument("--keyfile", help="Path to keypair file")
+    parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
     args = parser.parse_args()
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
     account = get_account(args.keyfile)
 
     deny_event, receipt = deny_reclaim_request(

--- a/scripts/deny_request.py
+++ b/scripts/deny_request.py
@@ -78,12 +78,12 @@ def main():
         description="Deny a reclaim request on the Collateral contract"
     )
     parser.add_argument(
-        "contract_address", help="Address of the deployed Collateral contract"
+        "--contract-address", required=True, help="Address of the deployed Collateral contract"
     )
     parser.add_argument(
-        "reclaim_request_id", type=int, help="ID of the reclaim request to deny"
+        "--reclaim-request-id", required=True, type=int, help="ID of the reclaim request to deny"
     )
-    parser.add_argument("url", help="URL containing the reason for denial")
+    parser.add_argument("--url", required=True, help="URL containing the reason for denial")
     args = parser.parse_args()
 
     w3 = get_web3_connection()

--- a/scripts/deny_request.py
+++ b/scripts/deny_request.py
@@ -84,10 +84,11 @@ def main():
         "--reclaim-request-id", required=True, type=int, help="ID of the reclaim request to deny"
     )
     parser.add_argument("--url", required=True, help="URL containing the reason for denial")
+    parser.add_argument("--keyfile", help="Path to keypair file")
     args = parser.parse_args()
 
     w3 = get_web3_connection()
-    account = get_account()
+    account = get_account(args.keyfile)
 
     deny_event, receipt = deny_reclaim_request(
         w3=w3,

--- a/scripts/deny_request.py
+++ b/scripts/deny_request.py
@@ -89,8 +89,7 @@ def main():
     parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
     args = parser.parse_args()
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
     account = get_account(args.keyfile)
 
     deny_event, receipt = deny_reclaim_request(

--- a/scripts/deposit_collateral.py
+++ b/scripts/deposit_collateral.py
@@ -92,16 +92,19 @@ def main():
         description="Deposit collateral into the Collateral smart contract"
     )
     parser.add_argument(
-        "contract_address",
+        "--contract-address",
+        required=True,
         help="Address of the Collateral contract"
     )
     parser.add_argument(
-        "amount_tao",
+        "--amount-tao",
+        required=True,
         type=float,
         help="Amount of TAO to deposit"
     )
     parser.add_argument(
-        "trustee_address",
+        "--trustee-address",
+        required=True,
         help="Expected trustee address to verify"
     )
 

--- a/scripts/deposit_collateral.py
+++ b/scripts/deposit_collateral.py
@@ -107,11 +107,12 @@ def main():
         required=True,
         help="Expected trustee address to verify"
     )
+    parser.add_argument("--keyfile", help="Path to keypair file")
 
     args = parser.parse_args()
 
     w3 = get_web3_connection()
-    account = get_account()
+    account = get_account(args.keyfile)
 
     deposit_event, receipt = deposit_collateral(
         w3=w3,

--- a/scripts/deposit_collateral.py
+++ b/scripts/deposit_collateral.py
@@ -11,6 +11,7 @@ executes the deposit transaction on the blockchain.
 import sys
 import argparse
 from web3 import Web3
+import bittensor.utils
 from common import (
     load_contract_abi,
     get_web3_connection,
@@ -108,10 +109,12 @@ def main():
         help="Expected trustee address to verify"
     )
     parser.add_argument("--keyfile", help="Path to keypair file")
+    parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
 
     args = parser.parse_args()
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
     account = get_account(args.keyfile)
 
     deposit_event, receipt = deposit_collateral(

--- a/scripts/deposit_collateral.py
+++ b/scripts/deposit_collateral.py
@@ -113,8 +113,7 @@ def main():
 
     args = parser.parse_args()
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
     account = get_account(args.keyfile)
 
     deposit_event, receipt = deposit_collateral(

--- a/scripts/finalize_reclaim.py
+++ b/scripts/finalize_reclaim.py
@@ -70,10 +70,10 @@ def main():
         description="Finalize a reclaim request on the Collateral contract"
     )
     parser.add_argument(
-        "contract_address", help="Address of the deployed Collateral contract"
+        "--contract-address", required=True, help="Address of the deployed Collateral contract"
     )
     parser.add_argument(
-        "reclaim_request_id", type=int, help="ID of the reclaim request to finalize"
+        "--reclaim-request-id", required=True, type=int, help="ID of the reclaim request to finalize"
     )
     args = parser.parse_args()
 

--- a/scripts/finalize_reclaim.py
+++ b/scripts/finalize_reclaim.py
@@ -80,8 +80,7 @@ def main():
     parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
     args = parser.parse_args()
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
     account = get_account(args.keyfile)
 
     try:

--- a/scripts/finalize_reclaim.py
+++ b/scripts/finalize_reclaim.py
@@ -10,6 +10,7 @@ the collateral to the user's address.
 
 import sys
 import argparse
+import bittensor.utils
 from common import (
     load_contract_abi,
     get_web3_connection,
@@ -76,9 +77,11 @@ def main():
         "--reclaim-request-id", required=True, type=int, help="ID of the reclaim request to finalize"
     )
     parser.add_argument("--keyfile", help="Path to keypair file")
+    parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
     args = parser.parse_args()
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
     account = get_account(args.keyfile)
 
     try:

--- a/scripts/finalize_reclaim.py
+++ b/scripts/finalize_reclaim.py
@@ -55,7 +55,7 @@ def finalize_reclaim(w3, account, reclaim_request_id, contract_address):
     )
 
     receipt = wait_for_receipt(w3, tx_hash)
-    
+
     if receipt['status'] == 0:
         # Try to get revert reason
         revert_reason = get_revert_reason(w3, tx_hash, receipt['blockNumber'])
@@ -75,10 +75,11 @@ def main():
     parser.add_argument(
         "--reclaim-request-id", required=True, type=int, help="ID of the reclaim request to finalize"
     )
+    parser.add_argument("--keyfile", help="Path to keypair file")
     args = parser.parse_args()
 
     w3 = get_web3_connection()
-    account = get_account()
+    account = get_account(args.keyfile)
 
     try:
         reclaim_event, receipt = finalize_reclaim(

--- a/scripts/generate_keypair.py
+++ b/scripts/generate_keypair.py
@@ -8,26 +8,26 @@ and saves it to a specified file. It's useful for creating new accounts for
 interacting with the Collateral smart contract.
 """
 
-import os
+import argparse
+import pathlib
 import sys
 import json
 from eth_account import Account
 from eth_keys import keys
 
 
-def generate_and_save_keypair(output_path: str, overwrite: bool = True) -> dict:
+def generate_and_save_keypair(output_path: pathlib.Path, overwrite: bool = False) -> dict:
     """
     Generate a new Ethereum key pair and save it to a file.
 
     Args:
-        output_path (str): Absolute path where the key pair should be saved
+        output_path (pathlib.Path): Path where the key pair should be saved.
+        overwrite (bool, optional): Whether to overwrite an existing file. Defaults to False.
 
     Returns:
         dict: Dictionary containing the account address, private key, and public key
-
-    Raises:
-        Exception: If there's an error saving the file
     """
+    output_path = output_path.expanduser().resolve()
     account = Account.create()
     private_key = keys.PrivateKey(account.key)
     public_key = private_key.public_key
@@ -35,9 +35,9 @@ def generate_and_save_keypair(output_path: str, overwrite: bool = True) -> dict:
     keypair_data = {
         "address": account.address,
         "private_key": account.key.hex(),
-        "public_key": public_key.to_hex()
+        "public_key": public_key.to_hex(),
     }
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w" if overwrite else "x") as f:
         json.dump(keypair_data, f, indent=2)
@@ -48,18 +48,25 @@ def generate_and_save_keypair(output_path: str, overwrite: bool = True) -> dict:
 
 
 def main():
-    if len(sys.argv) != 2:
-        print("Usage: python generate_keypair.py <output_path>")
-        print("Example: python generate_keypair.py keys/account.json")
-        sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the existing H160 file with the new one.",
+    )
+    parser.add_argument(
+        "output_path",
+        type=pathlib.Path,
+        help="Absolute path where the key pair should be saved",
+    )
+    args = parser.parse_args()
 
-    output_path = sys.argv[1]
-    generate_and_save_keypair(output_path)
-
-
-if __name__ == "__main__":
     try:
-        main()
+        generate_and_save_keypair(args.output_path, args.overwrite)
     except Exception as e:
         print(f"Error: {str(e)}", file=sys.stderr)
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_all_associations.py
+++ b/scripts/get_all_associations.py
@@ -1,0 +1,36 @@
+import argparse
+import sys
+
+import bittensor
+
+from common import get_evm_key_associations
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--netuid", type=int, required=True)
+    parser.add_argument("--block", type=int, default=None)
+    parser.add_argument("--network", default="finney")
+    args = parser.parse_args()
+
+    with bittensor.subtensor(network=args.network) as subtensor:
+        metagraph = subtensor.metagraph(netuid=args.netuid, block=args.block)
+        associations = get_evm_key_associations(subtensor, args.netuid, args.block)
+
+        if not associations:
+            print(f"No associations found for netuid {args.netuid}", file=sys.stderr)
+            sys.exit(1)
+
+        uid_to_hotkey_map = {neuron.uid: neuron.hotkey for neuron in metagraph.neurons}
+
+        print(f"EVM key associations for netuid {args.netuid}:\n")
+        print(" UID | Hotkey                                           | EVM Address")
+        print("-----|--------------------------------------------------|-------------------------------------------")
+        for uid in sorted(associations.keys()):
+            hotkey = uid_to_hotkey_map.get(uid, "Unknown")
+            evm_address = associations[uid]
+            print(f"{uid:4} | {hotkey:48} | {evm_address}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_balance.py
+++ b/scripts/get_balance.py
@@ -1,0 +1,25 @@
+import argparse
+
+from web3 import Web3
+import bittensor.utils
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("address")
+    parser.add_argument("--network", default="finney")
+    args = parser.parse_args()
+
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(
+        args.network,
+    )
+
+    w3 = Web3(Web3.LegacyWebSocketProvider(network_url))
+    balance = w3.eth.get_balance(args.address)
+
+    print("Account Balance:", w3.from_wei(balance, "ether"))
+    print("Account Balance (wei):", balance)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_collaterals.py
+++ b/scripts/get_collaterals.py
@@ -90,8 +90,7 @@ def main():
     parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
     args = parser.parse_args()
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
 
     deposit_events = get_deposit_events(
         w3, args.contract_address, args.block_start, args.block_end

--- a/scripts/get_collaterals.py
+++ b/scripts/get_collaterals.py
@@ -78,15 +78,14 @@ def main():
         description="Get collaterals for miners who deposited in a given block range"
     )
     parser.add_argument(
-        "contract_address", help="The address of the deployed Collateral contract"
+        "--contract-address", required=True, help="The address of the deployed Collateral contract"
     )
     parser.add_argument(
-        "block_start", type=int, help="Starting block number (inclusive)"
+        "--block-start", required=True, type=int, help="Starting block number (inclusive)"
     )
     parser.add_argument(
-        "block_end",
-        type=int,
-        help="Ending block number (inclusive)")
+        "--block-end", required=True, type=int, help="Ending block number (inclusive)"
+    )
     args = parser.parse_args()
 
     w3 = get_web3_connection()

--- a/scripts/get_collaterals.py
+++ b/scripts/get_collaterals.py
@@ -10,6 +10,7 @@ import argparse
 import csv
 import sys
 from collections import defaultdict
+import bittensor.utils
 from common import load_contract_abi, get_web3_connection, get_miner_collateral
 from dataclasses import dataclass
 
@@ -86,9 +87,11 @@ def main():
     parser.add_argument(
         "--block-end", required=True, type=int, help="Ending block number (inclusive)"
     )
+    parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
     args = parser.parse_args()
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
 
     deposit_events = get_deposit_events(
         w3, args.contract_address, args.block_start, args.block_end

--- a/scripts/get_current_block.py
+++ b/scripts/get_current_block.py
@@ -1,0 +1,21 @@
+import argparse
+
+import bittensor.utils
+from web3 import Web3
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--network", default="finney")
+    args = parser.parse_args()
+
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(
+        args.network,
+    )
+
+    w3 = Web3(Web3.LegacyWebSocketProvider(network_url))
+    print(w3.eth.get_block('latest')['number'])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_hotkey_association.py
+++ b/scripts/get_hotkey_association.py
@@ -1,0 +1,35 @@
+import argparse
+import sys
+
+import bittensor
+
+from common import get_evm_key_associations
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--netuid", type=int, required=True)
+    parser.add_argument("--hotkey", required=True)
+    parser.add_argument("--block", type=int, default=None)
+    parser.add_argument("--network", default="finney")
+    args = parser.parse_args()
+
+    with bittensor.subtensor(network=args.network) as subtensor:
+        # get the uid of the given hotkey from the metagraph
+        metagraph = subtensor.metagraph(netuid=args.netuid, block=args.block)
+        neurons = [neuron for neuron in metagraph.neurons if neuron.hotkey == args.hotkey]
+        if not neurons:
+            print(f"No neuron found for hotkey {args.hotkey} on netuid {args.netuid}", file=sys.stderr)
+            sys.exit(1)
+        uid = neurons[0].uid
+
+        associations = get_evm_key_associations(subtensor, args.netuid, args.block)
+        if uid not in associations:
+            print(f"No association found for hotkey {args.hotkey} on netuid {args.netuid}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"EVM key address for neuron {args.hotkey}(uid={uid}) on netuid {args.netuid}: {associations[uid]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_miners_collateral.py
+++ b/scripts/get_miners_collateral.py
@@ -12,6 +12,7 @@ The script will output the collateral amount in TAO (the native token).
 
 import argparse
 import sys
+import bittensor.utils
 from common import (
     get_web3_connection,
     get_miner_collateral,
@@ -34,13 +35,19 @@ def main():
         required=True,
         help="The address of the miner to query"
     )
-    
+    parser.add_argument(
+        "--network",
+        default="finney",
+        help="The Subtensor Network to connect to.",
+    )
+
     args = parser.parse_args()
-    
+
     validate_address_format(args.contract_address)
     validate_address_format(args.miner_address)
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
 
     collateral = get_miner_collateral(w3, args.contract_address, args.miner_address)
     print(

--- a/scripts/get_miners_collateral.py
+++ b/scripts/get_miners_collateral.py
@@ -46,8 +46,7 @@ def main():
     validate_address_format(args.contract_address)
     validate_address_format(args.miner_address)
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
 
     collateral = get_miner_collateral(w3, args.contract_address, args.miner_address)
     print(

--- a/scripts/get_miners_collateral.py
+++ b/scripts/get_miners_collateral.py
@@ -25,11 +25,13 @@ def main():
         description="Query the collateral amount for a specific miner in a smart contract"
     )
     parser.add_argument(
-        "contract_address",
+        "--contract-address",
+        required=True,
         help="The address of the smart contract"
     )
     parser.add_argument(
-        "miner_address",
+        "--miner-address",
+        required=True,
         help="The address of the miner to query"
     )
     

--- a/scripts/get_reclaim_requests.py
+++ b/scripts/get_reclaim_requests.py
@@ -107,8 +107,7 @@ def main():
 
     args = parser.parse_args()
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
     events = get_reclaim_process_started_events(
         w3, args.contract_address, args.block_start, args.block_end
     )

--- a/scripts/get_reclaim_requests.py
+++ b/scripts/get_reclaim_requests.py
@@ -12,6 +12,7 @@ import sys
 import csv
 import argparse
 from dataclasses import dataclass
+import bittensor.utils
 from common import get_web3_connection, load_contract_abi
 
 
@@ -98,10 +99,16 @@ def main():
     parser.add_argument(
         "--block-end", required=True, type=int, help="Ending block number (inclusive)"
     )
+    parser.add_argument(
+        "--network",
+        default="finney",
+        help="The Subtensor Network to connect to.",
+    )
 
     args = parser.parse_args()
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
     events = get_reclaim_process_started_events(
         w3, args.contract_address, args.block_start, args.block_end
     )

--- a/scripts/get_reclaim_requests.py
+++ b/scripts/get_reclaim_requests.py
@@ -90,15 +90,14 @@ def main():
     parser = argparse.ArgumentParser(
         description="Fetch ReclaimProcessStarted events from Collateral contract")
     parser.add_argument(
-        "contract_address", help="Address of the deployed Collateral contract"
+        "--contract-address", required=True, help="Address of the deployed Collateral contract"
     )
     parser.add_argument(
-        "block_start", type=int, help="Starting block number (inclusive)"
+        "--block-start", required=True, type=int, help="Starting block number (inclusive)"
     )
     parser.add_argument(
-        "block_end",
-        type=int,
-        help="Ending block number (inclusive)")
+        "--block-end", required=True, type=int, help="Ending block number (inclusive)"
+    )
 
     args = parser.parse_args()
 

--- a/scripts/h160_to_ss58.py
+++ b/scripts/h160_to_ss58.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-
+import argparse
 import sys
 from address_conversion import h160_to_ss58
 
-if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python h160_to_ss58.py <h160_address>")
-        sys.exit(1)
+
+def main():
+    parser = argparse.ArgumentParser(description="Get the SS58 address for a given H160 address")
+    parser.add_argument("address", help="The address to convert")
+    args = parser.parse_args()
 
     try:
-        print(h160_to_ss58(sys.argv[1]))
+        print(h160_to_ss58(args.address))
     except Exception as e:
         print(f"Error: {str(e)}", file=sys.stderr)
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/list_contracts.py
+++ b/scripts/list_contracts.py
@@ -6,6 +6,7 @@ import sys
 
 import bittensor.utils
 import bittensor_wallet
+from bittensor import rao
 from common import get_miner_collateral, get_web3_connection
 
 
@@ -105,7 +106,7 @@ async def main():
                 metagraph.hotkeys,
                 metagraph.total_stake,
             )
-            if stake >= stake_threshold.value
+            if stake >= rao(stake_threshold.value).tao
         }
         associations = {
             uid: bytes(association.value[0][0]).hex()

--- a/scripts/list_contracts.py
+++ b/scripts/list_contracts.py
@@ -68,13 +68,10 @@ async def main():
         print(f"Unable to decode H160 keyfile. {e}")
         sys.exit(1)
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(
-        args.network,
-    )
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
 
     async with bittensor.AsyncSubtensor(
-        network=network_url,
+        network=args.network,
     ) as subtensor:
         block = await subtensor.get_current_block()
 

--- a/scripts/reclaim_collateral.py
+++ b/scripts/reclaim_collateral.py
@@ -88,16 +88,19 @@ def main():
         description="Initiate the process of reclaiming collateral."
     )
     parser.add_argument(
-        "contract_address",
+        "--contract-address",
+        required=True,
         help="Address of the collateral contract"
     )
     parser.add_argument(
-        "amount_tao",
+        "--amount-tao",
+        required=True,
         type=float,
         help="Amount of TAO to reclaim"
     )
     parser.add_argument(
-        "url",
+        "--url",
+        required=True,
         help="URL for reclaim information"
     )
 

--- a/scripts/reclaim_collateral.py
+++ b/scripts/reclaim_collateral.py
@@ -103,13 +103,14 @@ def main():
         required=True,
         help="URL for reclaim information"
     )
+    parser.add_argument("--keyfile", help="Path to keypair file")
 
     args = parser.parse_args()
 
     validate_address_format(args.contract_address)
 
     w3 = get_web3_connection()
-    account = get_account()
+    account = get_account(args.keyfile)
 
     receipt, event = reclaim_collateral(
         w3, account, args.amount_tao, args.contract_address, args.url)

--- a/scripts/reclaim_collateral.py
+++ b/scripts/reclaim_collateral.py
@@ -115,8 +115,7 @@ def main():
 
     validate_address_format(args.contract_address)
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
     account = get_account(args.keyfile)
 
     receipt, event = reclaim_collateral(

--- a/scripts/reclaim_collateral.py
+++ b/scripts/reclaim_collateral.py
@@ -10,6 +10,7 @@ with associated URLs for verification purposes.
 
 import sys
 import argparse
+import bittensor.utils
 from common import (
     load_contract_abi,
     get_web3_connection,
@@ -104,12 +105,18 @@ def main():
         help="URL for reclaim information"
     )
     parser.add_argument("--keyfile", help="Path to keypair file")
+    parser.add_argument(
+        "--network",
+        default="finney",
+        help="The Subtensor Network to connect to.",
+    )
 
     args = parser.parse_args()
 
     validate_address_format(args.contract_address)
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
     account = get_account(args.keyfile)
 
     receipt, event = reclaim_collateral(

--- a/scripts/send_to_ss58_precompile.py
+++ b/scripts/send_to_ss58_precompile.py
@@ -81,8 +81,7 @@ def main():
     )
     args = parser.parse_args()
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
     account = get_account(args.keyfile)
     print(f"Using account: {account.address}")
 

--- a/scripts/send_to_ss58_precompile.py
+++ b/scripts/send_to_ss58_precompile.py
@@ -72,11 +72,11 @@ def main():
         type=int,
         help="The amount to send in wei (smallest unit of TAO)"
     )
-    
+    parser.add_argument("--keyfile", help="Path to keypair file")
     args = parser.parse_args()
 
     w3 = get_web3_connection()
-    account = get_account()
+    account = get_account(args.keyfile)
     print(f"Using account: {account.address}")
 
     receipt = send_tao_to_ss58(

--- a/scripts/send_to_ss58_precompile.py
+++ b/scripts/send_to_ss58_precompile.py
@@ -12,6 +12,7 @@ import argparse
 import sys
 from web3 import Web3
 from eth_account import Account
+import bittensor.utils
 from address_conversion import ss58_to_pubkey
 from common import get_web3_connection, get_account, wait_for_receipt, build_and_send_transaction
 
@@ -73,9 +74,15 @@ def main():
         help="The amount to send in wei (smallest unit of TAO)"
     )
     parser.add_argument("--keyfile", help="Path to keypair file")
+    parser.add_argument(
+        "--network",
+        default="finney",
+        help="The Subtensor Network to connect to.",
+    )
     args = parser.parse_args()
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
     account = get_account(args.keyfile)
     print(f"Using account: {account.address}")
 

--- a/scripts/send_to_ss58_precompile.py
+++ b/scripts/send_to_ss58_precompile.py
@@ -62,11 +62,13 @@ def main():
         description="Send TAO tokens to an SS58 address using the precompile contract"
     )
     parser.add_argument(
-        "recipient_ss58_address",
+        "--recipient-ss58-address",
+        required=True,
         help="The SS58 address of the recipient"
     )
     parser.add_argument(
-        "amount_wei",
+        "--amount-wei",
+        required=True,
         type=int,
         help="The amount to send in wei (smallest unit of TAO)"
     )

--- a/scripts/setup_evm.py
+++ b/scripts/setup_evm.py
@@ -54,6 +54,18 @@ def main():
         "--wallet-path",
         help="Path where the Wallets are located.",
     )
+    parser.add_argument(
+        "--deny-timeout",
+        type=int,
+        default=DENY_TIMEOUT,
+        help="Timeout for validators to deny a reclaim request in seconds. Default is 3 days.",
+    )
+    parser.add_argument(
+        "--min-collateral-increase",
+        type=int,
+        default=MIN_COLLATERAL_INCREASE,
+        help="Minimum collateral increase for miners for deposits in Wei. Default is 10000000000000, which is 0.01 TAO.",
+    )
     override_or_reuse = parser.add_mutually_exclusive_group()
     override_or_reuse.add_argument(
         "--overwrite",
@@ -133,8 +145,8 @@ def main():
                     "./deploy.sh",
                     str(args.netuid),
                     keypair["address"],
-                    str(MIN_COLLATERAL_INCREASE),
-                    str(DENY_TIMEOUT),
+                    str(args.min_collateral_increase),
+                    str(args.deny_timeout),
                 ],
                 capture_output=True,
                 check=True,

--- a/scripts/setup_evm.py
+++ b/scripts/setup_evm.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -139,6 +140,7 @@ def main():
                 check=True,
                 cwd=pathlib.Path(__file__).parents[1],
                 env={
+                    **os.environ,
                     "RPC_URL": network_url,
                     "DEPLOYER_PRIVATE_KEY": keypair["private_key"],
                 },

--- a/scripts/setup_evm.py
+++ b/scripts/setup_evm.py
@@ -18,7 +18,8 @@ MIN_COLLATERAL_INCREASE = 10000000000000  # 0.01 TAO
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "amount_tao",
+        "--amount-tao",
+        required=True,
         help="Amount of TAO to transfer to the EVM wallet",
         type=float,
     )

--- a/scripts/setup_evm.py
+++ b/scripts/setup_evm.py
@@ -93,7 +93,7 @@ def main():
         try:
             keypair = generate_and_save_keypair(output_path=keypair_path, overwrite=args.overwrite)
         except FileExistsError as e:
-            print(f"File {e.filename} already exists. Use --overwrite", file=sys.stderr)
+            print(f"File {e.filename} already exists. Use --overwrite or --reuse.", file=sys.stderr)
             sys.exit(1)
 
     with bittensor.Subtensor(
@@ -128,6 +128,7 @@ def main():
         try:
             contract = subprocess.run(
                 [
+                    "bash",
                     "./deploy.sh",
                     str(args.netuid),
                     keypair["address"],

--- a/scripts/slash_collateral.py
+++ b/scripts/slash_collateral.py
@@ -107,6 +107,7 @@ def main():
         required=True,
         help="URL containing information about the slash"
     )
+    parser.add_argument("--keyfile", help="Path to keypair file")
 
     args = parser.parse_args()
 
@@ -114,7 +115,7 @@ def main():
     validate_address_format(args.miner_address)
 
     w3 = get_web3_connection()
-    account = get_account()
+    account = get_account(args.keyfile)
 
     receipt, event = slash_collateral(
         w3,

--- a/scripts/slash_collateral.py
+++ b/scripts/slash_collateral.py
@@ -116,8 +116,7 @@ def main():
     validate_address_format(args.contract_address)
     validate_address_format(args.miner_address)
 
-    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
-    w3 = get_web3_connection(network_url)
+    w3 = get_web3_connection(args.network)
     account = get_account(args.keyfile)
 
     receipt, event = slash_collateral(

--- a/scripts/slash_collateral.py
+++ b/scripts/slash_collateral.py
@@ -87,20 +87,24 @@ def main():
         description="Slash collateral from a miner."
     )
     parser.add_argument(
-        "contract_address",
+        "--contract-address",
+        required=True,
         help="Address of the collateral contract"
     )
     parser.add_argument(
-        "miner_address",
+        "--miner-address",
+        required=True,
         help="Address of the miner to slash"
     )
     parser.add_argument(
-        "amount_tao",
+        "--amount-tao",
+        required=True,
         type=float,
         help="Amount of TAO to slash"
     )
     parser.add_argument(
-        "url",
+        "--url",
+        required=True,
         help="URL containing information about the slash"
     )
 

--- a/scripts/slash_collateral.py
+++ b/scripts/slash_collateral.py
@@ -10,6 +10,7 @@ URLs for verification purposes.
 
 import sys
 import argparse
+import bittensor.utils
 from common import (
     load_contract_abi,
     get_web3_connection,
@@ -108,13 +109,15 @@ def main():
         help="URL containing information about the slash"
     )
     parser.add_argument("--keyfile", help="Path to keypair file")
+    parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
 
     args = parser.parse_args()
 
     validate_address_format(args.contract_address)
     validate_address_format(args.miner_address)
 
-    w3 = get_web3_connection()
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(args.network)
+    w3 = get_web3_connection(network_url)
     account = get_account(args.keyfile)
 
     receipt, event = slash_collateral(

--- a/scripts/subtensor.py
+++ b/scripts/subtensor.py
@@ -1,5 +1,6 @@
 import bittensor
 import bittensor_wallet
+import eth_account
 import eth_utils
 import eth_keys.datatypes
 
@@ -7,7 +8,6 @@ import eth_keys.datatypes
 def associate_evm_key(
     subtensor: bittensor.Subtensor,
     wallet: bittensor_wallet.Wallet,
-    evm_address: str,
     evm_private_key: str,
     netuid: int,
 ) -> tuple[bool, str]:
@@ -15,16 +15,14 @@ def associate_evm_key(
     Associate an EVM key with a given wallet for a specific subnet.
 
     Args:
+        subtensor (bittensor.Subtensor): The Subtensor object to use for the transaction.
         wallet (bittensor.wallet): The wallet object containing the hotkey for signing
             the transaction. The wallet.hotkey will be associated with the EVM key.
-        evm_address (str): The Ethereum Virtual Machine (EVM) address to be associated
-            with the wallet.
         evm_private_key (str): The private key corresponding to the EVM address, used
             for signing the message.
-        network (str): The name of the Subtensor network where the EVM key is to be
-            associated.
         netuid (int): The numerical identifier (UID) of the Subtensor network.
     """
+    evm_address = eth_account.Account.from_key(evm_private_key).address
     eth_private_key = eth_keys.datatypes.PrivateKey(bytes.fromhex(evm_private_key))
 
     # subtensor encodes the u64 block number as little endian bytes before hashing

--- a/scripts/verify_contract.py
+++ b/scripts/verify_contract.py
@@ -162,10 +162,10 @@ def verify_contract(contract_address, expected_trustee, expected_netuid):
 
 def main():
     parser = argparse.ArgumentParser(description='Verify Collateral smart contract')
-    parser.add_argument('contract_address', help='The address of the deployed contract')
-    parser.add_argument('expected_trustee', help='Expected trustee address to verify')
-    parser.add_argument('expected_netuid', type=int, help='Expected netuid to verify')
-    
+    parser.add_argument('--contract-address', required=True, help='The address of the deployed contract')
+    parser.add_argument('--expected-trustee', required=True, help='Expected trustee address to verify')
+    parser.add_argument('--expected-netuid', required=True, type=int, help='Expected netuid to verify')
+
     args = parser.parse_args()
 
     if not Web3.is_address(args.contract_address):

--- a/scripts/verify_contract.py
+++ b/scripts/verify_contract.py
@@ -119,8 +119,7 @@ def deploy_on_devnet_and_get_bytecode(w3, contract_address):
 def verify_contract(contract_address, expected_trustee, expected_netuid, network="finney"):
     """Verify if the deployed contract matches the source code and expected values."""
     try:
-        _, network_url = bittensor.utils.determine_chain_endpoint_and_network(network)
-        w3 = get_web3_connection(network_url)
+        w3 = get_web3_connection(network)
 
         # Get contract configuration
         netuid, trustee, _decision_timeout, _min_collateral_increase = get_contract_config(w3, contract_address)

--- a/scripts/verify_contract.py
+++ b/scripts/verify_contract.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import time
 from web3 import Web3
+import bittensor.utils
 from common import get_web3_connection
 
 ANVIL_PORT = 8555
@@ -115,10 +116,11 @@ def deploy_on_devnet_and_get_bytecode(w3, contract_address):
         anvil_process.wait()
 
 
-def verify_contract(contract_address, expected_trustee, expected_netuid):
+def verify_contract(contract_address, expected_trustee, expected_netuid, network="finney"):
     """Verify if the deployed contract matches the source code and expected values."""
     try:
-        w3 = get_web3_connection()
+        _, network_url = bittensor.utils.determine_chain_endpoint_and_network(network)
+        w3 = get_web3_connection(network_url)
 
         # Get contract configuration
         netuid, trustee, _decision_timeout, _min_collateral_increase = get_contract_config(w3, contract_address)
@@ -165,6 +167,7 @@ def main():
     parser.add_argument('--contract-address', required=True, help='The address of the deployed contract')
     parser.add_argument('--expected-trustee', required=True, help='Expected trustee address to verify')
     parser.add_argument('--expected-netuid', required=True, type=int, help='Expected netuid to verify')
+    parser.add_argument("--network", default="finney", help="The Subtensor Network to connect to.")
 
     args = parser.parse_args()
 
@@ -172,7 +175,7 @@ def main():
         print("Error: Invalid contract address")
         sys.exit(1)
 
-    assert(verify_contract(args.contract_address, args.expected_trustee, args.expected_netuid))
+    assert(verify_contract(args.contract_address, args.expected_trustee, args.expected_netuid, args.network))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@mateuszsrebrny-reef the new cli interface:

```shell
# setup for validator
python scripts/setup_evm.py --network test --netuid 174 --wallet-name testnet-v --wallet-hotkey default --amount-tao 0.1 --deploy

# setup for miner
python scripts/setup_evm.py --network test --netuid 174 --wallet-name testnet-v --wallet-hotkey default --amount-tao 0.1

# For all the commands below that have `--keyfile`, you can alternatively set PRIVATE_KEY environment variable instead of passing --keyfile.

# deposit
python scripts/deposit_collateral.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --amount-tao 0.0001 --trustee-address 0x77407F1709D339f5583fEaC922C0592e248F785F --keyfile ~/.bittensor/wallets/testnet-v/h160/default --network test

# check balance for h160 address
python scripts/get_balance.py 0x77407F1709D339f5583fEaC922C0592e248F785F --network test

# h160 -> ss58 conversion (needed to transfer tao to evm wallet using btcli. setup initially transfers the specified amount, but if more is needed after setup, this can be used)
python scripts/h160_to_ss58.py 0x77407F1709D339f5583fEaC922C0592e248F785F

# get collateral for specific miner
python scripts/get_miners_collateral.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --miner-address 0x77407F1709D339f5583fEaC922C0592e248F785F --network test

# get collateral deposits made during block range
python scripts/get_current_block.py
python scripts/get_collaterals.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --block-start 5510156 --block-end 5510256 --network test

# verify contract
python scripts/verify_contract.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --expected-trustee 0x77407F1709D339f5583fEaC922C0592e248F785F --expected-netuid 174 --network test

# slash
python scripts/slash_collateral.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --miner-address 0x77407F1709D339f5583fEaC922C0592e248F785F --amount-tao 0.0001 --url 'lol' --network test --keyfile ~/.bittensor/wallets/testnet-v/h160/default

# reclaim request
python scripts/reclaim_collateral.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --amount-tao 0.0001 --url 'please :(' --keyfile ~/.bittensor/wallets/testnet-v/h160/default --network test

# finalize reclaim
python scripts/finalize_reclaim.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --reclaim-request-id 1 --keyfile ~/.bittensor/wallets/testnet-v/h160/default --network test

# deny reclaim
python scripts/deny_request.py --contract-address 0x7b89cb9B1D5B6A9F2296072885019D8Bfecc704A --reclaim-request-id 1 --url 'no lol' --keyfile ~/.bittensor/wallets/testnet-v/h160/default --network test
```
