### PR TITLE
[docs] non-coldkey flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,13 +439,13 @@ python scripts/setup_evm.py --deploy --verify --netuid 12 --amount-tao 0.2 --wal
 
 #### **Then continue with steps 4–8 from the recommended setup above** 
 Namely
-- 4. Transfer H160 Key to Validator Node
-- 5. Backup H160 Key
-- 6. Validator Code Uses the Contract
-- 7. Maintain Sufficient TAO for Gas
-- 8. Manual Reclaim Denials (Optional)
+4. Transfer H160 Key to Validator Node
+5. Backup H160 Key
+6. Validator Code Uses the Contract
+7. Maintain Sufficient TAO for Gas
+8. Manual Reclaim Denials (Optional)
 
-</details>
+details>
 
 ### As a Subnet Owner, you can
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ python scripts/setup_evm.py --netuid 12 --amount-tao 0 --wallet-name <YOUR COLDK
 - **Creates or reuses** a validator H160 wallet (`~/.bittensor/wallets/coldkey/h160/hotkey`):
   - Use `--reuse` to keep an existing identity.
   - Use `--overwrite` **with caution** – this deletes and replaces the private key (and thus access to any TAO previously sent to it).
-- **Associates** the H160 with the validator’s SS58 hotkey on the target `--netuid` (this requires a signature from your hotkey).
+- **Associates** the H160 with the validator’s SS58 hotkey on the target `--netuid` (this must be signed with your hotkey).
 - Prints the **SS58 address** to send TAO to.
 
 #### **2. Send TAO to that EVM address (from coldkey-controlled machine)**  

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Run the helper script on a machine that has access to your **coldkey**, to:
 
 ```bash
 # default: network: finney
-python scripts/setup_evm.py --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME> --amount-tao 1.2 
+python scripts/setup_evm.py --netuid 12 --amount-tao 1.2 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME> 
 ```
 
 - **Create or reuse** an H160 wallet under `~/.bittensor/wallets/coldkey/h160/hotkey`.
@@ -313,7 +313,7 @@ Run this on any machine where you have access to your hotkey:
 
 ```bash
 # defaults: network: finney
-python scripts/setup_evm.py --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME> --amount-tao 0
+python scripts/setup_evm.py --netuid 12 --amount-tao 0 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME>
 ```
 
 - **Creates or reuses** a validator H160 wallet (`~/.bittensor/wallets/coldkey/h160/hotkey`):
@@ -425,7 +425,7 @@ Run the helper script on a machine that has access to your coldkey:
 
 ```bash
 # defaults: deny timeout 5: days, min collateral increase: 0.01 TAO, network: finney
-python scripts/setup_evm.py --deploy --verify --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME> --amount-tao 0.2
+python scripts/setup_evm.py --deploy --verify --netuid 12 --amount-tao 0.2 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME>
 ```
 - **Creates or reuses** a validator H160 wallet (`~/.bittensor/wallets/coldkey/h160/hotkey`):
   - Use `--reuse` to keep an existing identity.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,17 @@ btcli w transfer --wallet-name <YOUR COLDKEY NAME> --recipient <SS58> --amount 0
 - Recommended: At least **0.01 TAO per validator** you plan to stake with (this is the current minimum for ComputeHorde, it will be increased to **10 TAO** when we are sure we slash justly).
 
 
-#### **3. Discover Validator Contracts**
+#### **3. Check Balance of EVM wallet**
+After successfully transferring TAO to your EVM wallet, you can check balance with:
+
+```bash
+python scripts/get_balance.py <EVM ADDRESS>
+```
+
+You can find you EVM address in `~/.bittensor/wallets/<YOUR WALLET>/h160/`.
+
+
+#### **4. Discover Validator Contracts**
 
 To find available validators:
 
@@ -217,12 +227,12 @@ HotKey 5EqqaqnwNLVofmrphyG5ZhQB6G5EPkVsYtZdw4UXyD4xMmjA
 - My Collateral: 0 TAO
 ```
 
-#### **4. Choose Trusted Validators**
+#### **5. Choose Trusted Validators**
 
 - Review the listed validators and decide which ones you trust to act fairly and slash responsibly.
 - You can choose one or multiple validators — just be sure to have enough TAO for each one.
 
-#### **5. Verify Contracts**
+#### **6. Verify Contracts**
 
 Before depositing:
 
@@ -244,7 +254,7 @@ Expected output:
 The deployed contract matches the source code.
 ```
 
-#### **6. Deposit Collateral**
+#### **7. Deposit Collateral**
 
 - Run [`scripts/deposit_collateral.py`](scripts/deposit_collateral.py) for each validator you trust.
 - Confirm on-chain that the deposit succeeded using [`scripts/get_miners_collateral.py`](scripts/get_miners_collateral.py).
@@ -259,12 +269,12 @@ python scripts/get_miners_collateral.py --contract-address <CONTRACT ADDRESS> --
 
 You should see your deposits on [Validator Dashboards on Grafana](https://grafana.bactensor.io/d/validator/metagraph-validator?var-subnet=12&var-validator=5HBVrFGy6oYhhh71m9fFGYD7zbKyAeHnWN8i8s9fJTBMCtEE&viewPanel=panel-1)
 
-#### **7. Receive Tasks and Monitor the Network**
+#### **8. Receive Tasks and Monitor the Network**
 
 - You will begin receiving **organic task assignments** from validators using your staked collateral as a signal.
 - Periodically re-run `list_contracts.py` to discover new validators or updated contracts you may want to deposit into.
 
-#### **8. Reclaim and Withdraw**
+#### **9. Reclaim and Withdraw**
 
 When you want to exit:
 
@@ -344,7 +354,16 @@ btcli w transfer --wallet-name <YOUR COLDKEY NAME> --recipient <SS58> --amount 0
 
 - Recommended: at least **0.2 TAO** to start (the contract deployment costs less than 0.02 TAO, and each slashing action uses around 0.0005 TAO in gas).
 
-#### **3. Deploy and publish the contract with `setup_evm.py --deploy --verify`**  
+#### **3. Check Balance of EVM wallet**
+After successfully transferring TAO to your EVM wallet, you can check balance with:
+
+```bash
+python scripts/get_balance.py <EVM ADDRESS>
+```
+
+You can find you EVM address in `~/.bittensor/wallets/<YOUR WALLET>/h160/`.
+
+#### **4. Deploy and publish the contract with `setup_evm.py --deploy --verify`**  
 Then, on your validator node (or any machine you used to execute step 1):
 
 ```bash
@@ -356,7 +375,7 @@ python scripts/setup_evm.py --reuse --amount-tao 0 --deploy --verify --netuid 12
 - **Publishes the contract address** as a **knowledge commitment** on-chain, enabling miners and other tools to discover and verify it.
 
 
-#### **4. Transfer H160 Key to Validator Node**
+#### **5. Transfer H160 Key to Validator Node**
 
 Copy the generated H160 key files to your validator machine. 
 If you used the validator machine for previous steps the key is already in the right place.
@@ -367,13 +386,13 @@ scp -r ~/.bittensor/wallets/<YOUR WALLET>/h160 <YOUR VALI USERNAME>@<YOUR VALI H
 
 You do **not** need to transfer the coldkey — the h160 private key file is sufficient for all contract interactions.
 
-#### **5. Backup H160 Key**
+#### **6. Backup H160 Key**
 
 Make sure you don't lose the H160 key files.   
 You would lose the funds and would have to deploy the contract again.  
 Miners’ funds remain safe — they can reclaim their collateral even if you lose your private key.
 
-#### **6. Validator Code Uses the Contract**
+#### **7. Validator Code Uses the Contract**
 
 The validator code provided by the subnet owner:
 
@@ -383,7 +402,7 @@ The validator code provided by the subnet owner:
   - Initially slashes **tiny amounts** to calibrate the logic.
   - Later increases slashing severity to discourage misbehavior.
 
-#### **7. Maintain Sufficient TAO for Gas**
+#### **8. Maintain Sufficient TAO for Gas**
 
 Slashing operations consume gas.
 Validators must keep their H160 wallet funded to support this:
@@ -407,7 +426,7 @@ Then use btcli on a machine with your coldkey to transfer funds:
 btcli w transfer --amount 0.2 --recipient <SS58 FROM ABOVE>
 ```
 
-#### **8. Manual Reclaim Denials (Optional)**
+#### **9. Manual Reclaim Denials (Optional)**
 
 In rare cases where cheating is **suspected but not yet confirmed** by automation:
 

--- a/README.md
+++ b/README.md
@@ -326,10 +326,10 @@ python scripts/setup_evm.py --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wall
 On your coldkey machine:
 
 ```bash
-btcli w transfer --wallet-name <YOUR COLDKEY NAME> --recipient <SS58> --amount 1
+btcli w transfer --wallet-name <YOUR COLDKEY NAME> --recipient <SS58> --amount 0.2
 ```
 
-- Recommended: at least **1 TAO** to start (the contract deployment costs less than 0.02 TAO, and each slashing action uses around 0.0005 TAO in gas).
+- Recommended: at least **0.2 TAO** to start (the contract deployment costs less than 0.02 TAO, and each slashing action uses around 0.0005 TAO in gas).
 
 #### **3. Deploy and publish the contract with `setup_evm.sh --deploy --verify`**  
 Back on your validator (or same hotkey-accessible machine as Step 1):
@@ -390,7 +390,7 @@ python scripts/h160_to_ss58.py <YOUR H160 ADDRESS>
 
 Then use btcli on a machine with your coldkey to transfer funds:
 ```bash
-btcli w transfer --amount 1 --recipient <SS58 FROM ABOVE>
+btcli w transfer --amount 0.2 --recipient <SS58 FROM ABOVE>
 ```
 
 #### **8. Manual Reclaim Denials (Optional)**
@@ -425,13 +425,13 @@ Run the helper script on a machine that has access to your validator coldkey:
 
 ```bash
 # defaults: deny timeout 5: days, min collateral increase: 0.01 $Tao, network: finney
-python scripts/setup_evm.py --deploy --verify --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME> --amount-tao 1
+python scripts/setup_evm.py --deploy --verify --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME> --amount-tao 0.2
 ```
 - **Creates or reuses** a validator H160 wallet (`~/.bittensor/wallets/coldkey/h160/hotkey`):
   - Use `--reuse` to keep an existing identity.
   - Use `--overwrite` **with caution** – this deletes and replaces the private key (and thus access to any TAO previously sent to it).
 - **Associates** the H160 with the validator’s SS58 hotkey on the target `--netuid` (this requires to be signed with your hotkey).
-- **Transfers funds** to the wallet (recommended: at least **1 TAO** to start - the contract deployment costs less than 0.02 TAO, and each slashing action uses around 0.0005 TAO in gas)
+- **Transfers funds** to the wallet (recommended: at least **0.2 TAO** to start - the contract deployment costs less than 0.02 TAO, and each slashing action uses around 0.0005 TAO in gas)
 - **Deploys the collateral contract** to subtensor.
 - With `--verify`, it also **verifies the mainnet contract on [evm.taostats.io](https://evm.taostats.io)** for public transparency.
 - **Publishes the contract address** as a **knowledge commitment** on-chain, enabling miners and other tools to discover and verify it.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,10 @@ You do **not** need to transfer the coldkey — the h160 private key file is suf
 
 #### **5. Backup H160 Key**
 
-Make sure you don't lose the H160 key files. You would lose the funds and would have to deploy the contract again. 
+Make sure you don't lose the H160 key files.  
+
+You would lose the funds and would have to deploy the contract again. 
+
 Miners’ funds remain safe — they can reclaim their collateral even if you lose your private key.
 
 #### **6. Validator Code Uses the Contract**

--- a/README.md
+++ b/README.md
@@ -439,13 +439,13 @@ python scripts/setup_evm.py --deploy --verify --netuid 12 --amount-tao 0.2 --wal
 
 #### **Then continue with steps 4–8 from the recommended setup above** 
 Namely
-4. Transfer H160 Key to Validator Node
-5. Backup H160 Key
-6. Validator Code Uses the Contract
-7. Maintain Sufficient TAO for Gas
-8. Manual Reclaim Denials (Optional)
+  4. Transfer H160 Key to Validator Node
+  5. Backup H160 Key
+  6. Validator Code Uses the Contract
+  7. Maintain Sufficient TAO for Gas
+  8. Manual Reclaim Denials (Optional)
 
-details>
+</details>
 
 ### As a Subnet Owner, you can
 

--- a/README.md
+++ b/README.md
@@ -168,12 +168,25 @@ python scripts/setup_evm.py --netuid 12 --amount-tao 1.2 --wallet-name <YOUR COL
     More TAO can be transferred to the H160 wallet later too.
   - At least **0.01 TAO per validator** you plan to stake with (this is the current minimum for ComputeHorde, it will be increased to **10 TAO** when we are sure we slash justly).
   - Plus additional TAO to cover **gas fees** for deposit, reclaim, and finalize transactions — we recommend **~0.2 TAO extra**.
+  - If you don't have access to your wallet coldkey on this machine, you can run this script with `--amount-tao 0`.
+    It will print the SS58 address of the EVM wallet you can manually transfer TAO to.
 - **Associate** the H160 wallet with your miner hotkey on the appropriate `--netuid`.
 
 > Note: This is the same script validators use, but without the `--deploy` flag.
 > You do **NOT** need to deploy a contract or copy the private key to your miner machine.
 
-#### **2. Discover Validator Contracts**
+#### **2. (OPTIONAL) Send TAO to that EVM address (from coldkey-controlled machine)**  
+If you used `--amount-tao 0` in the previous step, it printed the SS58 address of your EVM wallet.
+Send TAO to that wallet from your coldkey machine:
+
+```bash
+btcli w transfer --wallet-name <YOUR COLDKEY NAME> --recipient <SS58> --amount 0.2
+```
+
+- Recommended: At least **0.01 TAO per validator** you plan to stake with (this is the current minimum for ComputeHorde, it will be increased to **10 TAO** when we are sure we slash justly).
+
+
+#### **3. Discover Validator Contracts**
 
 To find available validators:
 
@@ -204,12 +217,12 @@ HotKey 5EqqaqnwNLVofmrphyG5ZhQB6G5EPkVsYtZdw4UXyD4xMmjA
 - My Collateral: 0 TAO
 ```
 
-#### **3. Choose Trusted Validators**
+#### **4. Choose Trusted Validators**
 
 - Review the listed validators and decide which ones you trust to act fairly and slash responsibly.
 - You can choose one or multiple validators — just be sure to have enough TAO for each one.
 
-#### **4. Verify Contracts**
+#### **5. Verify Contracts**
 
 Before depositing:
 
@@ -231,7 +244,7 @@ Expected output:
 The deployed contract matches the source code.
 ```
 
-#### **5. Deposit Collateral**
+#### **6. Deposit Collateral**
 
 - Run [`scripts/deposit_collateral.py`](scripts/deposit_collateral.py) for each validator you trust.
 - Confirm on-chain that the deposit succeeded using [`scripts/get_miners_collateral.py`](scripts/get_miners_collateral.py).
@@ -246,12 +259,12 @@ python scripts/get_miners_collateral.py --contract-address <CONTRACT ADDRESS> --
 
 You should see your deposits on [Validator Dashboards on Grafana](https://grafana.bactensor.io/d/validator/metagraph-validator?var-subnet=12&var-validator=5HBVrFGy6oYhhh71m9fFGYD7zbKyAeHnWN8i8s9fJTBMCtEE&viewPanel=panel-1)
 
-#### **6. Receive Tasks and Monitor the Network**
+#### **7. Receive Tasks and Monitor the Network**
 
 - You will begin receiving **organic task assignments** from validators using your staked collateral as a signal.
 - Periodically re-run `list_contracts.py` to discover new validators or updated contracts you may want to deposit into.
 
-#### **7. Reclaim and Withdraw**
+#### **8. Reclaim and Withdraw**
 
 When you want to exit:
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Checkout the [screencast](https://asciinema.org/a/720833) to see command-by-comm
   If you plan to stake for multiple validators, simply repeat these steps for each one:
   - Obtain the validator's contract address (usually via tools provided by the subnet owner).
   - Verify that code deployed at the address is indeed the collateral smart contract, the trustee and netuid kept inside are as expected - see [`scripts/verify_contract.py`](/scripts/verify_contract.py).
-  - Run [`scripts/deposit_collateral.py`](/scripts/deposit_collateral.py) to initiate the deposit transaction with your specified amount of $TAO.
+  - Run [`scripts/deposit_collateral.py`](/scripts/deposit_collateral.py) to initiate the deposit transaction with your specified amount of TAO.
   - Confirm on-chain that your collateral has been successfully locked for that validator - [`scripts/get_miners_collateral.py`](/scripts/get_miners_collateral.py)
 
 - **Reclaim Collateral**
@@ -335,7 +335,7 @@ btcli w transfer --wallet-name <YOUR COLDKEY NAME> --recipient <SS58> --amount 0
 Then, on your validator node (or any machine you used to execute step 1):
 
 ```bash
-# defaults: deny timeout 5: days, min collateral increase: 0.01 $Tao, network: finney
+# defaults: deny timeout 5: days, min collateral increase: 0.01 TAO, network: finney
 python scripts/setup_evm.py --reuse --amount-tao 0 --deploy --verify --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME>
 ```
 - **Deploys the collateral contract** to subtensor.
@@ -405,7 +405,7 @@ In rare cases where cheating is **suspected but not yet confirmed** by automatio
 
 </details>
 
-### Alternative Flow (More Convenient but Requires Coldkey Access)
+### Alternative Validator Integration Guide (More Convenient but Requires Coldkey Access)
 
 If you're comfortable running a script on your coldkey-enabled machine, you can use this simpler setup:
 
@@ -424,7 +424,7 @@ If you're comfortable running a script on your coldkey-enabled machine, you can 
 Run the helper script on a machine that has access to your coldkey:
 
 ```bash
-# defaults: deny timeout 5: days, min collateral increase: 0.01 $Tao, network: finney
+# defaults: deny timeout 5: days, min collateral increase: 0.01 TAO, network: finney
 python scripts/setup_evm.py --deploy --verify --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wallet-hotkey <YOUR HOTKEY NAME> --amount-tao 0.2
 ```
 - **Creates or reuses** a validator H160 wallet (`~/.bittensor/wallets/coldkey/h160/hotkey`):
@@ -452,7 +452,7 @@ Namely
   
   Offer a script <!--(e.g. built on top of [`scripts/deploy.sh`](todo-link))--> to help validators:
   - Create H160 wallet & assosiate it with their SS58.
-  - Transfer Tao.
+  - Transfer TAO.
   - Deploy the contract.
   - Publish the resulting contract address (e.g., as a knowledge commitment) so miners can easily verify and deposit collateral.
 

--- a/README.md
+++ b/README.md
@@ -493,10 +493,9 @@ Most of them are already linked inline in the **Usage Guides** above, but this s
   - Associates it with a hotkey.
   - Optionally funds it with TAO (set `--amount-tao 0` to skip).
   - For validators, optionally deploys and verifies a new contract (`--deploy --verify`) and publishes the contract address as a knowledge commitment.
-
-> 🛡️ **Security-First Validator Setup Tip**:  
-> To avoid running scripts on your coldkey machine, run `setup_evm.py` with `--amount-tao 0`, manually transfer TAO to the printed SS58 address, then run again with `--reuse --amount-tao 0 --deploy --verify`.  
-> See [Recommended Validator Integration Guide](#recommended-validator-integration-guide-security-first-as-used-by-computehorde) for full steps.
+  - 🛡️ **Security-First Validator Setup Tip**:  
+    To avoid running scripts on your coldkey machine, run `setup_evm.py` with `--amount-tao 0`, manually transfer TAO to the printed SS58 address, then run again with `--reuse --amount-tao 0 --deploy --verify`.  
+    See [Recommended Validator Integration Guide](#recommended-validator-integration-guide-security-first-as-used-by-computehorde) for full steps.
 
 - [`send_to_ss58_precompile.py`](scripts/send_to_ss58_precompile.py) – Transfers TAO from an H160 wallet back to an SS58 address once contract interactions are complete.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Other subnets may follow the same process — no changes are needed beyond the `
 - Install [Foundry](https://book.getfoundry.sh/) (needed because verification scripts call Foundry tools internally).
 - Make sure `pip install -r requirements.txt` is done.
 
-#### **1. Setup with `setup_evm.sh`**
+#### **1. Setup with `setup_evm.py`**
 
 Run the helper script on a machine that has access to your **coldkey**, to:
 
@@ -291,7 +291,7 @@ When you want to exit:
   - When new miner exploits are discovered, updated validator logic will be released by the subnet owner.
   - Keeping your validator software up-to-date ensures that new automated slashing logic is deployed and running — helping to maintain network integrity.
 
-### Recommended Validator Integration Guide (as used by ComputeHorde)
+### Recommended Validator Integration Guide (Security-First, as used by ComputeHorde)
 
 This is the recommended security-first validator integration flow currently used by the **ComputeHorde** subnet (`sn12`).
 It doesn't require running scripts on coldkey machines.
@@ -319,7 +319,7 @@ python scripts/setup_evm.py --netuid 12 --wallet-name <YOUR COLDKEY NAME> --wall
 - **Creates or reuses** a validator H160 wallet (`~/.bittensor/wallets/coldkey/h160/hotkey`):
   - Use `--reuse` to keep an existing identity.
   - Use `--overwrite` **with caution** – this deletes and replaces the private key (and thus access to any TAO previously sent to it).
-- **Associates** the H160 with the validator’s SS58 hotkey on the target `--netuid` (this requires to be signed with your hotkey).
+- **Associates** the H160 with the validator’s SS58 hotkey on the target `--netuid` (this requires a signature from your hotkey).
 - Prints the **SS58 address** to send TAO to.
 
 #### **2. Send TAO to that EVM address (from coldkey-controlled machine)**  
@@ -331,8 +331,8 @@ btcli w transfer --wallet-name <YOUR COLDKEY NAME> --recipient <SS58> --amount 0
 
 - Recommended: at least **0.2 TAO** to start (the contract deployment costs less than 0.02 TAO, and each slashing action uses around 0.0005 TAO in gas).
 
-#### **3. Deploy and publish the contract with `setup_evm.sh --deploy --verify`**  
-Back on your validator (or same hotkey-accessible machine as Step 1):
+#### **3. Deploy and publish the contract with `setup_evm.py --deploy --verify`**  
+Then, on your validator node (or any machine you used to execute step 1):
 
 ```bash
 # defaults: deny timeout 5: days, min collateral increase: 0.01 $Tao, network: finney
@@ -356,8 +356,8 @@ You do **not** need to transfer the coldkey — the h160 private key file is suf
 
 #### **5. Backup H160 Key**
 
-Make sure you don't loose the H160 key files. You would loose the funds and would have to deploy the contract again. 
-Miners' funds will be safe, they are able to reclaim them without your private key. 
+Make sure you don't lose the H160 key files. You would lose the funds and would have to deploy the contract again. 
+Miners’ funds remain safe — they can reclaim their collateral even if you lose your private key.
 
 #### **6. Validator Code Uses the Contract**
 
@@ -419,9 +419,9 @@ If you're comfortable running a script on your coldkey-enabled machine, you can 
 - Make sure `pip install -r requirements.txt` is done.
 
 
-#### **1. One-Step Deployment with Coldkey Machine with `setup_evm.sh --deploy --verify`**
+#### **1. One-Step Deployment with Coldkey Machine with `setup_evm.py --deploy --verify`**
 
-Run the helper script on a machine that has access to your validator coldkey:
+Run the helper script on a machine that has access to your coldkey:
 
 ```bash
 # defaults: deny timeout 5: days, min collateral increase: 0.01 $Tao, network: finney
@@ -436,7 +436,7 @@ python scripts/setup_evm.py --deploy --verify --netuid 12 --wallet-name <YOUR CO
 - With `--verify`, it also **verifies the mainnet contract on [evm.taostats.io](https://evm.taostats.io)** for public transparency.
 - **Publishes the contract address** as a **knowledge commitment** on-chain, enabling miners and other tools to discover and verify it.
 
-#### **Proceed with steps 4 through 8 of the recommended setup** 
+#### **Then continue with steps 4–8 from the recommended setup above** 
 Namely
 - 4. Transfer H160 Key to Validator Node
 - 5. Backup H160 Key

--- a/README.md
+++ b/README.md
@@ -487,7 +487,16 @@ Most of them are already linked inline in the **Usage Guides** above, but this s
 
 ### **Getting Started & Finalizing**
 
-- [`setup_evm.py`](scripts/setup_evm.py) – End-to-end setup script for both miners and validators: generates or reuses an H160 wallet, associates it with a hotkey, and funds it with TAO. Validators continue by deploying the contract and publishing its address.
+- [`setup_evm.py`](scripts/setup_evm.py) – End-to-end setup script for both miners and validators.  
+  - Generates or reuses an H160 wallet.
+  - Associates it with a hotkey.
+  - Optionally funds it with TAO (set `--amount-tao 0` to skip).
+  - For validators, optionally deploys and verifies a new contract (`--deploy --verify`) and publishes the contract address as a knowledge commitment.
+
+> 🛡️ **Security-First Validator Setup Tip**:  
+> To avoid running scripts on your coldkey machine, run `setup_evm.py` with `--amount-tao 0`, manually transfer TAO to the printed SS58 address, then run again with `--reuse --amount-tao 0 --deploy --verify`.  
+> See [Recommended Validator Integration Guide](#recommended-validator-integration-guide-security-first-as-used-by-computehorde) for full steps.
+
 - [`send_to_ss58_precompile.py`](scripts/send_to_ss58_precompile.py) – Transfers TAO from an H160 wallet back to an SS58 address once contract interactions are complete.
 
 ### **Contract Interaction – Miners**

--- a/README.md
+++ b/README.md
@@ -438,12 +438,12 @@ python scripts/setup_evm.py --deploy --verify --netuid 12 --amount-tao 0.2 --wal
 - **Publishes the contract address** as a **knowledge commitment** on-chain, enabling miners and other tools to discover and verify it.
 
 #### **Then continue with steps 4–8 from the recommended setup above** 
-Namely
-  4. Transfer H160 Key to Validator Node
-  5. Backup H160 Key
-  6. Validator Code Uses the Contract
-  7. Maintain Sufficient TAO for Gas
-  8. Manual Reclaim Denials (Optional)
+Namely:  
+4. Transfer H160 Key to Validator Node  
+5. Backup H160 Key  
+6. Validator Code Uses the Contract  
+7. Maintain Sufficient TAO for Gas  
+8. Manual Reclaim Denials (Optional)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -494,9 +494,9 @@ Most of them are already linked inline in the **Usage Guides** above, but this s
   - Optionally funds it with TAO (set `--amount-tao 0` to skip).
   - For validators, optionally deploys and verifies a new contract (`--deploy --verify`) and publishes the contract address as a knowledge commitment.
   - 🛡️ **Security-First Validator Setup Tip**:  
-    To avoid running scripts on your coldkey machine, run `setup_evm.py` with `--amount-tao 0`, manually transfer TAO to the printed SS58 address, then run again with `--reuse --amount-tao 0 --deploy --verify`.  
+    To avoid running scripts on your coldkey machine, run `setup_evm.py` with `--amount-tao 0`, manually transfer TAO to the printed SS58 address,
+    then run again with `--reuse --amount-tao 0 --deploy --verify`.
     See [Recommended Validator Integration Guide](#recommended-validator-integration-guide-security-first-as-used-by-computehorde) for full steps.
-
 - [`send_to_ss58_precompile.py`](scripts/send_to_ss58_precompile.py) – Transfers TAO from an H160 wallet back to an SS58 address once contract interactions are complete.
 
 ### **Contract Interaction – Miners**

--- a/README.md
+++ b/README.md
@@ -356,10 +356,8 @@ You do **not** need to transfer the coldkey — the h160 private key file is suf
 
 #### **5. Backup H160 Key**
 
-Make sure you don't lose the H160 key files.  
-
-You would lose the funds and would have to deploy the contract again. 
-
+Make sure you don't lose the H160 key files.   
+You would lose the funds and would have to deploy the contract again.  
 Miners’ funds remain safe — they can reclaim their collateral even if you lose your private key.
 
 #### **6. Validator Code Uses the Contract**

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ When you want to exit:
   - Clone this repository.
   - Compile and deploy the contract.
   - Record the deployed contract address and publish it via a subnet-owner-provided tool so that miners can discover and verify it.
-  - You can use `scripts/setup_evm.py` (recommended) as described [here](#recommended-validator-integration-guide-as-used-by-computehorde), or run `./deploy.sh` and other scripts directly if you prefer to do the steps manually.
+  - You can use `scripts/setup_evm.py` (recommended) as described [here](##recommended-validator-integration-guide-security-first-as-used-by-computehorde), or run `./deploy.sh` and other scripts directly if you prefer to do the steps manually.
 
 - **Enable Regular Operation**
   - Enable the deployed contract address in your validator's code (provided by the subnet owner), so that

--- a/scripts/setup_evm.py
+++ b/scripts/setup_evm.py
@@ -143,6 +143,9 @@ def main():
                 print(f"Unable to Transfer TAO to generated EVM wallet.", file=sys.stderr)
                 sys.exit(1)
 
+        else:
+            print(f"Transfer Tao to `{h160_to_ss58(keypair['address'])}` in order to top up {keypair['address']}.", flush=True)
+
         if not args.deploy:
             return
 


### PR DESCRIPTION
In this PR:
- [x] a flow which doesn't required coldkey is described
- [x] it is mentioned also in the script reference
- [x] amount of tao for vali is changed to 0.2 (there is an explainer parenthesis too)
- [x] some formatting is cleared
- [x] the script_evm.py now prints ss58 address in case `--amount-tao 0`