### PR TITLE
Use hotkey to sign association call

### DIFF
--- a/scripts/subtensor.py
+++ b/scripts/subtensor.py
@@ -55,4 +55,5 @@ def associate_evm_key(
         wallet,
         wait_for_inclusion=True,
         wait_for_finalization=True,
+        sign_with="hotkey",
     )


### PR DESCRIPTION
Ref: https://github.com/opentensor/subtensor/pull/1764

The subtensor is deployed on testnet and seems to be released for mainnet on [v3.1.6](https://github.com/opentensor/subtensor/releases/tag/v3.1.6) (it is a pre-release, but [v3.1.7](https://github.com/opentensor/subtensor/releases/tag/v3.1.7) is also released). But it still doesn't work (released but not deployed?). Wait to merge this PR until it works on mainnet.