### PR TITLE
[scripts] publishing contract knowledge commitment

### DIFF
--- a/scripts/get_all_associations.py
+++ b/scripts/get_all_associations.py
@@ -4,6 +4,7 @@ import sys
 import bittensor
 
 from common import get_evm_key_associations
+from web3 import Web3
 
 
 def main() -> None:
@@ -28,7 +29,7 @@ def main() -> None:
         print("-----|--------------------------------------------------|-------------------------------------------")
         for uid in sorted(associations.keys()):
             hotkey = uid_to_hotkey_map.get(uid, "Unknown")
-            evm_address = associations[uid]
+            evm_address = Web3.to_checksum_address(associations[uid])
             print(f"{uid:4} | {hotkey:48} | {evm_address}")
 
 

--- a/scripts/list_contracts.py
+++ b/scripts/list_contracts.py
@@ -86,6 +86,7 @@ async def main():
 
             try:
                 evm_address = associations[validators[hotkey]]
+                evm_address = w3.to_checksum_address(evm_address)
             except KeyError:
                 evm_address = "?"
 
@@ -99,7 +100,7 @@ async def main():
                 continue
 
             print(f"HotKey {hotkey}")
-            print(f"- EVM Address: 0x{evm_address}")
+            print(f"- EVM Address: {evm_address}")
             print(f"- Contract Address: {contract_address}")
 
             # collateral checking is a blocking function so we make it optional

--- a/scripts/publish_contract_address.py
+++ b/scripts/publish_contract_address.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+import sys
+
+import bittensor
+import bittensor.utils
+import bittensor_wallet
+
+from common import validate_address_format
+
+def publish_contract_address(subtensor, wallet, netuid, contract_address):
+    try:
+        print("Publishing contract address as knowledge commitment.", flush=True)
+        subtensor.commit(
+            wallet,
+            netuid=netuid,
+            data=json.dumps(
+                {
+                    "contract": {
+                        "address": contract_address,
+                    },
+                }
+            ),
+        )
+    except bittensor.MetadataError as e:
+        print(f"Unable to Publish Contract Address. {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--contract-address", 
+        required=True, 
+        help="The address of the deployed Collateral contract",
+    )
+    parser.add_argument(
+        "--netuid",
+        help="Netuid of the Subnet in the Network.",
+        required=True,
+        type=int,
+    )
+    parser.add_argument(
+        "--network",
+        default="finney",
+        help="The Subtensor Network to connect to.",
+    )
+    parser.add_argument(
+        "--wallet-hotkey",
+        default="default",
+        help="Hotkey of the Wallet",
+    )
+    parser.add_argument(
+        "--wallet-name",
+        required=True,
+        help="Name of the Wallet.",
+    )
+    parser.add_argument(
+        "--wallet-path",
+        help="Path where the Wallets are located.",
+    )
+
+    args = parser.parse_args()
+
+    validate_address_format(args.contract_address)
+
+    wallet = bittensor_wallet.Wallet(
+        name=args.wallet_name,
+        hotkey=args.wallet_hotkey,
+        path=args.wallet_path,
+    )
+    _, network_url = bittensor.utils.determine_chain_endpoint_and_network(
+        args.network,
+    )
+
+    with bittensor.Subtensor(
+        network=network_url,
+    ) as subtensor:
+
+        publish_contract_address(subtensor, wallet, args.netuid, args.contract_address)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_contract_address.py
+++ b/scripts/publish_contract_address.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import sys
 
 import bittensor
@@ -7,24 +6,7 @@ import bittensor.utils
 import bittensor_wallet
 
 from common import validate_address_format
-
-def publish_contract_address(subtensor, wallet, netuid, contract_address):
-    try:
-        print("Publishing contract address as knowledge commitment.", flush=True)
-        subtensor.commit(
-            wallet,
-            netuid=netuid,
-            data=json.dumps(
-                {
-                    "contract": {
-                        "address": contract_address,
-                    },
-                }
-            ),
-        )
-    except bittensor.MetadataError as e:
-        print(f"Unable to Publish Contract Address. {e}", file=sys.stderr)
-        sys.exit(1)
+from subtensor import publish_contract_address as publish_contract_address_onchain
 
 
 def main():
@@ -76,8 +58,16 @@ def main():
     with bittensor.Subtensor(
         network=network_url,
     ) as subtensor:
-
-        publish_contract_address(subtensor, wallet, args.netuid, args.contract_address)
+        try:
+            publish_contract_address_onchain(
+                subtensor,
+                wallet,
+                args.netuid,
+                args.contract_address,
+            )
+        except bittensor.MetadataError as e:
+            print(f"Unable to Publish Contract Address. {e}", file=sys.stderr)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/setup_evm.py
+++ b/scripts/setup_evm.py
@@ -10,7 +10,7 @@ import bittensor.utils
 import bittensor_wallet
 from address_conversion import h160_to_ss58
 from generate_keypair import generate_and_save_keypair
-from subtensor import associate_evm_key
+from subtensor import associate_evm_key, publish_contract_address as publish_contract_address_onchain
 
 DENY_TIMEOUT = 5 * 24 * 60 * 60  # 5 days
 MIN_COLLATERAL_INCREASE = 10000000000000  # 0.01 TAO
@@ -203,16 +203,11 @@ def main():
 
         try:
             print("Publishing contract address as knowledge commitment.", flush=True)
-            subtensor.commit(
+            publish_contract_address_onchain(
+                subtensor,
                 wallet,
-                netuid=args.netuid,
-                data=json.dumps(
-                    {
-                        "contract": {
-                            "address": contract_address,
-                        },
-                    }
-                ),
+                args.netuid,
+                contract_address,
             )
         except bittensor.MetadataError as e:
             print(f"Unable to Publish Contract Address. {e}", file=sys.stderr)

--- a/scripts/setup_evm.py
+++ b/scripts/setup_evm.py
@@ -71,6 +71,11 @@ def main():
         default=MIN_COLLATERAL_INCREASE,
         help="Minimum collateral increase for miners for deposits in Wei. Default is 10000000000000, which is 0.01 TAO.",
     )
+    parser.add_argument(
+        "--skip-association",
+        action="store_true",
+        help="Don't try associating the EVM key with your hotkey"
+    )
     override_or_reuse = parser.add_mutually_exclusive_group()
     override_or_reuse.add_argument(
         "--overwrite",
@@ -117,17 +122,19 @@ def main():
     with bittensor.Subtensor(
         network=network_url,
     ) as subtensor:
-        print(f"Associating {keypair['address']} with your hotkey.", flush=True)
-        success, error = associate_evm_key(
-            subtensor,
-            wallet,
-            keypair["private_key"],
-            args.netuid,
-        )
+        
+        if not args.skip_association:
+            print(f"Associating {keypair['address']} with your hotkey.", flush=True)
+            success, error = associate_evm_key(
+                subtensor,
+                wallet,
+                keypair["private_key"],
+                args.netuid,
+            )
 
-        if not success:
-            print(f"Unable to Associate EVM Key. {error}", file=sys.stderr)
-            sys.exit(1)
+            if not success:
+                print(f"Unable to Associate EVM Key. {error}", file=sys.stderr)
+                sys.exit(1)
 
         if args.amount_tao > 0:
             print(f"Transfering {args.amount_tao} to {keypair['address']}.", flush=True)

--- a/scripts/subtensor.py
+++ b/scripts/subtensor.py
@@ -1,3 +1,5 @@
+import json
+
 import bittensor
 import bittensor_wallet
 import eth_account
@@ -56,4 +58,25 @@ def associate_evm_key(
         wait_for_inclusion=True,
         wait_for_finalization=True,
         sign_with="hotkey",
+    )
+
+
+def publish_contract_address(
+    subtensor: bittensor.Subtensor,
+    wallet: bittensor_wallet.Wallet,
+    netuid: int,
+    contract_address: str,
+) -> None:
+    """Publish the collateral contract address as a knowledge commitment."""
+
+    subtensor.commit(
+        wallet,
+        netuid=netuid,
+        data=json.dumps(
+            {
+                "contract": {
+                    "address": contract_address,
+                },
+            }
+        ),
     )

--- a/test/Collateral.t.sol
+++ b/test/Collateral.t.sol
@@ -290,8 +290,9 @@ contract CollateralTest is CollateralTestBase {
         verifyReclaim(2, DEPOSITOR1, 1 ether, block.timestamp + DECISION_TIMEOUT);
     }
 
-    function test_finalizeReclaim_DeletesReclaimRequestAndDoesNotReturnCollateralIfMinerGotCollateralSlashedBelowReclaimAmount(
-    ) public {
+    function test_finalizeReclaim_DeletesReclaimRequestAndDoesNotReturnCollateralIfMinerGotCollateralSlashedBelowReclaimAmount()
+        public
+    {
         vm.startPrank(DEPOSITOR1);
         collateral.deposit{value: 2 ether}();
 


### PR DESCRIPTION
In this PR:
- [x] publish_contract_address.py script is added
- [x] publishing removed from setup_evm and made generic to be used there and in new script
- [x] fixing get_all_associations and list_contracts to print checksummed addresses - so they are ready to be copied and pasted as input for other scripts
- [x] added option to `setup_evm` to skip the association part
- [x] a little formatting fix so that `forge fmt doesn't complain` 